### PR TITLE
Add metrics tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,21 @@ Example:
 ```bash
 $ istioctl mixer rule create global ratings.default.svc.cluster.local -f istio/samples/apps/bookinfo/mixer-rule-ratings-denial.yaml --kube=false --mixerAPIService=localhost:9094
 ```
+# Privacy Notice
+
+Sample Kubernetes Yaml file that includes this package may be configured to track deployments to [IBM Cloud](https://www.bluemix.net/) and other Kubernetes platforms. The following information is sent to a [Deployment Tracker](https://github.com/IBM/metrics-collector-service) service on each deployment:
+
+* Kubernetes Cluster Provider(`IBM Cloud,Minikube,etc`)
+* Kubernetes Machine ID
+* Kubernetes Cluster ID (Only from IBM Cloud's cluster)
+* Kubernetes Customer ID (Only from IBM Cloud's cluster)
+* Environment variables in this Kubernetes Job.
+
+This data is collected from the Kubernetes Job in the sample application's yaml file. This data is used by IBM to track metrics around deployments of sample applications to IBM Cloud to measure the usefulness of our examples so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
+
+## Disabling Deployment Tracking
+
+Please comment out/remove the Metric Kubernetes Job portion at the end of the 'bookinfo.yaml' file.
 
 # References
 [Istio.io](https://istio.io/docs/tasks/index.html)

--- a/bookinfo.yaml
+++ b/bookinfo.yaml
@@ -80,3 +80,24 @@ spec:
         backend:
           serviceName: reviews
           servicePort: 9080
+---
+apiVersion: batch/v1
+kind: Job
+metadata: {name: microservices-traffic-management-using-istio-metrics}
+spec:
+  template:
+    metadata: {name: microservices-traffic-management-using-istio-metrics}
+    spec:
+      containers:
+        - env:
+            - {name: config, value: '{"event_id": "web",
+                "repository_id": "microservices-traffic-management-using-istio",
+                "target_services": [null], "target_runtimes":
+                ["Kubernetes Cluster"], "event_organizer":
+                "dev-journeys"}'}
+            - {name: language, value: 'java'}
+          image: journeycode/kubernetes:latest
+          name: java-microprofile-on-kubernetes-metrics
+          resources:
+            limits: {cpu: 100m}
+      restartPolicy: Never


### PR DESCRIPTION
This commit adds the metrics tracker from
https://github.com/IBM/metrics-collector-client-kubernetes

fixes #53