### PR TITLE
Remove 'precise' specification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 before_install:
 - bash scripts/install.sh
 group: stable
-dist: precise
 os: linux
 notifications:
   slack:


### PR DESCRIPTION
Ubuntu Precise is no longer supported.  Stop using it for Travis
builds.